### PR TITLE
Update install script version for mmlspark

### DIFF
--- a/Code/01_Data_Acquisition_and_Understanding/01_HDInsight_Spark_Provisioning/template.json
+++ b/Code/01_Data_Acquisition_and_Understanding/01_HDInsight_Spark_Provisioning/template.json
@@ -117,7 +117,7 @@
                             "scriptActions": [
                                 {
                                     "name": "mmlspark",
-                                    "uri": "https://mmlspark.azureedge.net/buildartifacts/0.7/install-mmlspark.sh",
+                                    "uri": "https://mmlspark.azureedge.net/buildartifacts/0.10/install-mmlspark.sh",
                                     "parameters": "",
                                     "isHeadNode": true,
                                     "isWorkerNode": true,
@@ -145,7 +145,7 @@
                             "scriptActions": [
                                 {
                                     "name": "mmlspark",
-                                    "uri": "https://mmlspark.azureedge.net/buildartifacts/0.7/install-mmlspark.sh",
+                                    "uri": "https://mmlspark.azureedge.net/buildartifacts/0.10/install-mmlspark.sh",
                                     "parameters": "",
                                     "isHeadNode": true,
                                     "isWorkerNode": true,


### PR DESCRIPTION
The older version of mmlspark install script fails when trying to pick up the conda environment with an error that looks like this:

```
/tmp/tmp2lnGXt: line 50: CNTK_WHEELS[$env]: Unknown conda env for CNTK: base
Traceback (most recent call last):
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/run_customscriptaction.py", line 194, in <module>
    ExecuteScriptAction().execute()
  File "/usr/lib/python2.6/site-packages/resource_management/libraries/script/script.py", line 329, in execute
    method(env)
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/run_customscriptaction.py", line 179, in actionexecute
    ExecuteScriptAction.execute_bash_script(bash_script, scriptpath, scriptparams)
  File "/var/lib/ambari-agent/cache/custom_actions/scripts/run_customscriptaction.py", line 149, in execute_bash_script
    raise Exception("Execution of custom script failed with exit code",exitcode)
Exception: ('Execution of custom script failed with exit code', 1)
```

Upgrading the script version to 0.10 resolved the error.